### PR TITLE
Make CLI compatible with the new settings page in Rekono

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is a Command Line Interface to manage the [Rekono](https://github.com/pablo
 
 > :warning: Commands to manage Rekono installation are only advised for local and personal usage in Linux environements. Otherwise [Docker](https://github.com/pablosnt/rekono#docker) is advised.
 
+You can reach Rekono in http://127.0.0.1:3000/
 
 ## Installation
 

--- a/rekono/installation/configuration.py
+++ b/rekono/installation/configuration.py
@@ -3,7 +3,6 @@ from getpass import getpass
 from typing import List
 
 import yaml
-
 from rekono.config import (CMSEEK_DIR, DB_DATABASE, DB_USER, GITTOOLS_DIR,
                            LOG4J_SCANNER_DIR, REKONO_HOME_DIRECTORY)
 
@@ -24,8 +23,6 @@ def create_config_file(db_password: str) -> None:
                 'localhost',
                 '::1'
             ],
-            'otp-expiration-hours': 24,
-            'upload-files-max-mb': 500
         },
         'database': {
             'name': DB_DATABASE,
@@ -44,19 +41,6 @@ def create_config_file(db_password: str) -> None:
             'user': input('SMTP user: '),
             'password': getpass('SMTP password: '),
             'tls': True
-        },
-        'telegram': {
-            'bot': 'Rekono',
-            'token': getpass('Telegram token: '),
-        },
-        'defect-dojo': {
-            'url': input('Defect-Dojo URL [Format <protocol>://<host>]: '),
-            'api-key': getpass('Defect-Dojo API key: '),
-            'verify': True,
-            'tags': ['rekono'],
-            'product-type': 'Rekono Project',
-            'test-type': 'Rekono Findings Import',
-            'test': 'Rekono Test'
         },
         'tools': {
             'cmseek': {

--- a/rekono/installation/configuration.py
+++ b/rekono/installation/configuration.py
@@ -15,7 +15,7 @@ def create_config_file(db_password: str) -> None:
     '''
     config = {                                                                  # Prepare configuration file
         'frontend': {
-            'url': 'http://127.0.0.1:8080'
+            'url': 'http://127.0.0.1:3000'
         },
         'security': {
             'allowed-hosts': [


### PR DESCRIPTION
The following configurations will be removed from the configuration file:

- Defect-Dojo configuration
- Telegram configuration
- Max size for uploaded files
- Time life for the invitation OTP

The implementation of the new settings page is available here: https://github.com/pablosnt/rekono/pull/71